### PR TITLE
updating to 1.1.1 to release aar per INTENG-7084

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=1.1.0
-VERSION_CODE=010100
+VERSION_NAME=1.1.1
+VERSION_CODE=010101
 GROUP=io.branch.sdk.android
 
 POM_NAME=Branch Adobe Android SDK


### PR DESCRIPTION
## Reference
INTENG-7084

## Description
According to INTENG-7084 (and confirmed by checking Maven) we didn't release the aar during the last release.

## Risk Assessment [`HIGH | MEDIUM | LOW`]
low

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

**You can only merge once all of these are checked off!**

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
