### PR TITLE
fixed library imports after migration to androidx (in test classes)

### DIFF
--- a/AdobeBranchExample/src/androidTest/assets/swag_data.json
+++ b/AdobeBranchExample/src/androidTest/assets/swag_data.json
@@ -1,0 +1,20 @@
+{
+   "success": true,
+   "request_id": "4d65c2ba-d88a-4356-a157-7ed04676b28e",
+   "catalog": [
+      {
+         "id": 1,
+         "title": "Branch Glasses",
+         "description": "New Branch Wayfarer style classic sunglasses",
+         "image_url": "https://cdn.branch.io/branch-assets/1538165719615-og_image.jpeg",
+         "price": 12.99
+      },
+      {
+         "id": 2,
+         "title": "Branch Stickers",
+         "description": "Decorative Branch Stickers to make your day",
+         "image_url": "https://cdn.shopify.com/s/files/1/1885/8385/products/circle_sticker.png?v=1490843770",
+         "price": 1.49
+      }
+   ]
+}

--- a/AdobeBranchExample/src/androidTest/java/io/branch/sample/testadobebranch/BaseTest.java
+++ b/AdobeBranchExample/src/androidTest/java/io/branch/sample/testadobebranch/BaseTest.java
@@ -1,8 +1,9 @@
 package io.branch.sample.testadobebranch;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+
+import androidx.test.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Before;
@@ -22,7 +23,7 @@ public class BaseTest {
 
     @Before
     public void setUp() {
-        mContext = InstrumentationRegistry.getTargetContext();
+        mContext = InstrumentationRegistry.getContext();
     }
 
     @After
@@ -31,8 +32,8 @@ public class BaseTest {
     }
 
     @Test
-    public void testContext() {
-        assertEquals("io.branch.adobe.demo", mContext.getPackageName());
+    public void testPackageName() {
+        assertEquals("io.branch.adobe.demo.test", mContext.getPackageName());
     }
 
     Context getTestContext() {

--- a/AdobeBranchExample/src/androidTest/java/io/branch/sample/testadobebranch/TestDataModel.java
+++ b/AdobeBranchExample/src/androidTest/java/io/branch/sample/testadobebranch/TestDataModel.java
@@ -1,6 +1,6 @@
 package io.branch.sample.testadobebranch;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.json.JSONObject;
 import org.junit.Assert;

--- a/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeBranchTest.java
+++ b/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeBranchTest.java
@@ -1,14 +1,11 @@
 package io.branch.adobe.extension.test;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
 
@@ -17,14 +14,14 @@ import io.branch.referral.Branch;
 /**
  * Base Instrumented test, which will execute on an Android device.
  */
-@RunWith(AndroidJUnit4.class)
+import androidx.test.InstrumentationRegistry;
 public class AdobeBranchTest {
     private Context mContext;
 
     @Before
     public void setUp() {
         Branch.enableDebugMode();
-        mContext = InstrumentationRegistry.getTargetContext();
+        mContext = InstrumentationRegistry.getContext();
     }
 
     @After

--- a/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeBranchTest.java
+++ b/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeBranchTest.java
@@ -2,10 +2,14 @@ package io.branch.adobe.extension.test;
 
 import android.content.Context;
 
+import androidx.test.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
 import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
 
@@ -14,7 +18,7 @@ import io.branch.referral.Branch;
 /**
  * Base Instrumented test, which will execute on an Android device.
  */
-import androidx.test.InstrumentationRegistry;
+@RunWith(AndroidJUnit4.class)
 public class AdobeBranchTest {
     private Context mContext;
 

--- a/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeEventTest.java
+++ b/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeEventTest.java
@@ -1,6 +1,6 @@
 package io.branch.adobe.extension.test;
 
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.util.Log;
 
 import com.adobe.marketing.mobile.AdobeCallback;


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/SDK-665

## Description
In PR #8 we migrated the project to androidx but never updated the library imports in test classes.

## Testing Instructions
Run all the tests: `./gradlew :AdobeBranchExtension:connectedDebugAndroidTest`

## Risk Assessment [`HIGH | MEDIUM | LOW`]
LOW

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

**You can only merge once all of these are checked off!**

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
