### PR TITLE
INTENG-8009/all-adobe-ids

### DIFF
--- a/AdobeBranchExample/src/main/java/io/branch/adobe/demo/DemoApplication.java
+++ b/AdobeBranchExample/src/main/java/io/branch/adobe/demo/DemoApplication.java
@@ -29,6 +29,7 @@ public class DemoApplication extends Application {
         initBranch();
         initAdobeBranch();
         registerAdobeBranchExtension();
+//        Analytics.setVisitorIdentifier("custom_identifier_123"); // to test custom visitor ID (key: "vid")
     }
 
     private void initBranch() {

--- a/AdobeBranchExample/src/main/java/io/branch/adobe/demo/ProductActivity.java
+++ b/AdobeBranchExample/src/main/java/io/branch/adobe/demo/ProductActivity.java
@@ -34,7 +34,6 @@ import io.branch.referral.util.LinkProperties;
 import io.branch.referral.util.ShareSheetStyle;
 
 public class ProductActivity extends AppCompatActivity {
-    private static final String TAG = "Branch::ProductActivity";
     private List<SwagModel> swagModelList;
 
     @Override
@@ -93,8 +92,7 @@ public class ProductActivity extends AppCompatActivity {
         AdobeBranch.initSession(new Branch.BranchReferralInitListener() {
             @Override
             public void onInitFinished(JSONObject referringParams, BranchError error) {
-                PrefHelper.Debug("JSON: " + referringParams.toString());
-
+                if (referringParams == null) return;
                 try {
                     // You would think that there was an easier way to figure this out than looking at LinkProperties code
                     if (referringParams.has("+clicked_branch_link") && referringParams.getBoolean("+clicked_branch_link")) {

--- a/AdobeBranchExtension/build.gradle
+++ b/AdobeBranchExtension/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     javadocDeps 'io.branch.sdk.android:library:4.2.0'
 
     // Adobe
+    androidTestImplementation 'com.adobe.marketing.mobile:userprofile:1.0.1'
     implementation 'com.adobe.marketing.mobile:sdk-core:1.4.6'
 }
 

--- a/AdobeBranchExtension/build.gradle
+++ b/AdobeBranchExtension/build.gradle
@@ -29,17 +29,15 @@ configurations {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // Branch
-    api 'io.branch.sdk.android:library:4.1.2'
-    javadocDeps 'io.branch.sdk.android:library:4.1.2'
+    api 'io.branch.sdk.android:library:4.2.0'
+    javadocDeps 'io.branch.sdk.android:library:4.2.0'
 
     // Adobe
-    implementation 'com.adobe.marketing.mobile:userprofile:1.0.1'
     implementation 'com.adobe.marketing.mobile:sdk-core:1.4.6'
 }
 

--- a/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
+++ b/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
@@ -1,6 +1,7 @@
 package io.branch.adobe.extension;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.Extension;
@@ -168,21 +169,21 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
                 PrefHelper.Debug(String.format("identity extension shared state = %s", new JSONObject(extensionSharedState)));
             }
             for (Map.Entry<String, Object> entry :extensionSharedState.entrySet()) {
-                Object value = entry.getValue();
-                if (value == null || value.toString().length() == 0 || "null".equalsIgnoreCase(value.toString())) continue;
+                String value = (String) entry.getValue();
+                if (TextUtils.isEmpty(value)) continue;
                 // pass
                 switch (entry.getKey()) {
                     case "mid":
                         // pass Adobe Experience Cloud ID (https://app.gitbook.com/@aep-sdks/s/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#getExperienceCloudIdTitle)
-                        branch.setRequestMetadata("$marketing_cloud_visitor_id", entry.getValue().toString());
+                        branch.setRequestMetadata("$marketing_cloud_visitor_id", value);
                         break;
                     case "vid":
                         // pass Adobe Custom Visitor ID (https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-analytics/analytics-api-reference#getvisitoridentifier)
-                        branch.setRequestMetadata("$analytics_visitor_id", entry.getValue().toString());
+                        branch.setRequestMetadata("$analytics_visitor_id", value);
                         break;
                     case "aid":
                         // pass Adobe Tracking ID (https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-analytics/analytics-api-reference#gettrackingidentifier)
-                        branch.setRequestMetadata("$adobe_visitor_id", entry.getValue().toString());
+                        branch.setRequestMetadata("$adobe_visitor_id", value);
                         break;
                 }
             }

--- a/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
+++ b/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
@@ -11,6 +11,7 @@ import com.adobe.marketing.mobile.ExtensionErrorCallback;
 import org.json.JSONObject;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -26,9 +27,12 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
     private static final String ADOBE_TRACK_EVENT = "com.adobe.eventtype.generic.track";
     private static final String ADOBE_EVENT_SOURCE = "com.adobe.eventsource.requestcontent";
 
-    private static final String ADOBE_IDENTITY_EVENT = "com.adobe.module.identity";
-    public static final String ADOBE_IDENTITY_EVENT_TYPE = "com.adobe.eventtype.identity";
-    public static final String ADOBE_IDENTITY_EVENT_SOURCE = "com.adobe.eventsource.responseidentity";
+    private static final String ADOBE_IDENTITY_EXTENSION = "com.adobe.module.identity";
+    private static final String ADOBE_ANALYTICS_EXTENSION = "com.adobe.module.analytics";
+
+    private static final String ADOBE_HUB_EVENT_TYPE = "com.adobe.eventtype.hub";
+    private static final String ADOBE_SHARED_STATE_EVENT_SOURCE = "com.adobe.eventsource.sharedstate";
+    private static final String ADOBE_SHARED_STATE_EVENT_OWNER_KEY = "stateowner";
 
     static final String BRANCH_CONFIGURATION_EVENT = "io.branch.eventtype.configuration";
     static final String BRANCH_EVENT_SOURCE = "io.branch.eventsource.configurecontent";
@@ -62,7 +66,7 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
         // Register default Event Listeners
         registerExtension(ADOBE_TRACK_EVENT, ADOBE_EVENT_SOURCE);
         registerExtension(BRANCH_CONFIGURATION_EVENT, BRANCH_EVENT_SOURCE);
-        registerExtension(ADOBE_IDENTITY_EVENT_TYPE, ADOBE_IDENTITY_EVENT_SOURCE);
+        registerExtension(ADOBE_HUB_EVENT_TYPE, ADOBE_SHARED_STATE_EVENT_SOURCE);
     }
 
     private void registerExtension(String eventType, String eventSource) {
@@ -80,8 +84,8 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
 
         if (isBranchConfigurationEvent(event)) {
             handleBranchConfigurationEvent(event);
-        } else if (isIdentityEvent(event)) {
-            handleIdentityEvent(event);
+        } else if (isSharedStateEvent(event)) {
+            handleSharedStateEvent(event);
         } else if (isTrackedEvent(event)) {
             handleEvent(event);
         } else {
@@ -107,8 +111,8 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
         return (event.getType().equals(BRANCH_CONFIGURATION_EVENT) && event.getSource().equals(BRANCH_EVENT_SOURCE));
     }
 
-    private boolean isIdentityEvent(final Event event) {
-        return (event.getType().equals(ADOBE_IDENTITY_EVENT_TYPE) && event.getSource().equals(ADOBE_IDENTITY_EVENT_SOURCE));
+    private boolean isSharedStateEvent(final Event event) {
+        return (event.getType().equals(ADOBE_HUB_EVENT_TYPE) && event.getSource().equals(ADOBE_SHARED_STATE_EVENT_SOURCE));
     }
 
     /**
@@ -145,29 +149,43 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
     }
 
     /**
-     * Handle the Identity event by passing the Adobe ID to Branch
+     * Handle "shared state change" events by checking if the owner of a given event is one of the
+     * extensions that keeps track of Adobe IDs (e.g. Identity/Analytics). If so, get the shared state of
+     * that extension and retrieve the Adobe IDs if they are present, then pass the IDs to Branch.
+     * https://aep-sdks.gitbook.io/docs/resources/building-mobile-extensions/requesting-a-shared-state
      * @param event Adobe Event
      */
-    private void handleIdentityEvent(final Event event) {
-        Map<String, Object> identitySharedState = getApi().getSharedEventState(ADOBE_IDENTITY_EVENT, event, this);
-        Branch branch = Branch.getInstance();
-        if (branch != null && identitySharedState != null) {
-            PrefHelper.Debug(String.format("The identitySharedState is: %s", new JSONObject(identitySharedState)));
-            for (Map.Entry<String, Object> entry :identitySharedState.entrySet()) {
+    private void handleSharedStateEvent(final Event event) {
+        final Branch branch = Branch.getInstance();
+        if (branch != null && event != null && event.getEventData() != null) {
+            Map<String, Object> extensionSharedState = new HashMap<>();
+            Object stateowner = event.getEventData().get(ADOBE_SHARED_STATE_EVENT_OWNER_KEY);
+            if (ADOBE_ANALYTICS_EXTENSION.equals(stateowner)) {
+                extensionSharedState = getApi().getSharedEventState(ADOBE_ANALYTICS_EXTENSION, event, this);
+                PrefHelper.Debug(String.format("analytics extension shared state = %s", new JSONObject(extensionSharedState)));
+            } else if (ADOBE_IDENTITY_EXTENSION.equals(stateowner)) {
+                extensionSharedState = getApi().getSharedEventState(ADOBE_IDENTITY_EXTENSION, event, this);
+                PrefHelper.Debug(String.format("identity extension shared state = %s", new JSONObject(extensionSharedState)));
+            }
+            for (Map.Entry<String, Object> entry :extensionSharedState.entrySet()) {
+                Object value = entry.getValue();
+                if (value == null || value.toString().length() == 0 || "null".equalsIgnoreCase(value.toString())) continue;
+                // pass
                 switch (entry.getKey()) {
                     case "mid":
+                        // pass Adobe Experience Cloud ID (https://app.gitbook.com/@aep-sdks/s/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#getExperienceCloudIdTitle)
                         branch.setRequestMetadata("$marketing_cloud_visitor_id", entry.getValue().toString());
                         break;
                     case "vid":
+                        // pass Adobe Custom Visitor ID (https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-analytics/analytics-api-reference#getvisitoridentifier)
                         branch.setRequestMetadata("$analytics_visitor_id", entry.getValue().toString());
                         break;
                     case "aid":
+                        // pass Adobe Tracking ID (https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-analytics/analytics-api-reference#gettrackingidentifier)
                         branch.setRequestMetadata("$adobe_visitor_id", entry.getValue().toString());
                         break;
                 }
             }
-        } else {
-            PrefHelper.Debug("Warning: identitySharedState is null");
         }
     }
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,8 @@
 # Adobe Branch SDK Extension change log
+- v1.1.3
+  * _*Master Release*_ - November 19, 2019
+  * Patch: automatically pick up all Adobe IDs and pass it to Branch
+  
 - v1.1.2
   * _*Master Release*_ - November 19, 2019
   * Automatically pick up Adobe ID and pass it to Branch

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=1.1.2
-VERSION_CODE=010102
+VERSION_NAME=1.1.3
+VERSION_CODE=010103
 GROUP=io.branch.sdk.android
 
 POM_NAME=Branch Adobe Android SDK


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/INTENG-8009

## Description
I was blindly trying to retrieve custom visitor id and tracking id from the shared state of the wrong extension, chatted with Adobe, figured out the right away, which is to listen to shared state changes, then check whose (which extension's) shared state changed, then retrieve the latest share state of that extension and obtain the IDs from there (Identity -> "mid", Analytics -> "vid"/"aid").

## Testing Instructions
Run the AdobeBranchExample app, an filter logcat with `extension shared state`, you can uncomment `setVisitorIdentifier` method in `DemoApplication` to see the "vid" value change.

## Risk Assessment [`HIGH | MEDIUM | LOW`]
LOW

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

**You can only merge once all of these are checked off!**

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
