### PR TITLE
INTENG-9038

### DIFF
--- a/AdobeBranchExample/.gitignore
+++ b/AdobeBranchExample/.gitignore
@@ -1,1 +1,11 @@
+*.iml
+/local.properties
+.DS_Store
 /build
+/captures
+
+/.idea/
+/.gradle/
+gradle/
+gradlew
+gradlew.bat

--- a/AdobeBranchExample/src/main/AndroidManifest.xml
+++ b/AdobeBranchExample/src/main/AndroidManifest.xml
@@ -60,15 +60,6 @@
             android:name="io.branch.sdk.BranchKey"
             android:value="key_live_nbB0KZ4UGOKaHEWCjQI2ThncEAeRJmhy" />
 
-        <!-- Branch install referrer tracking (optional) -->
-        <receiver
-            android:name="io.branch.referral.InstallListener"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.android.vending.INSTALL_REFERRER" />
-            </intent-filter>
-        </receiver>
-
     </application>
 
 </manifest>

--- a/AdobeBranchExample/src/main/java/io/branch/adobe/demo/DemoApplication.java
+++ b/AdobeBranchExample/src/main/java/io/branch/adobe/demo/DemoApplication.java
@@ -2,8 +2,6 @@ package io.branch.adobe.demo;
 
 import com.adobe.marketing.mobile.AdobeCallback;
 import com.adobe.marketing.mobile.Analytics;
-import com.adobe.marketing.mobile.ExtensionError;
-import com.adobe.marketing.mobile.ExtensionErrorCallback;
 import com.adobe.marketing.mobile.Identity;
 import com.adobe.marketing.mobile.InvalidInitException;
 import com.adobe.marketing.mobile.Lifecycle;
@@ -13,12 +11,10 @@ import com.adobe.marketing.mobile.Signal;
 import com.adobe.marketing.mobile.UserProfile;
 
 import android.app.Application;
-import io.branch.adobe.extension.AdobeBranch;
 import io.branch.adobe.extension.AdobeBranchExtension;
 import io.branch.referral.*;
 
 public class DemoApplication extends Application {
-    private static final String TAG = "DemoApplication::";
     private static final String ADOBE_APP_ID = "d10f76259195/b0503e1a5dce/launch-9948a3b3a89d-development";
 
     @Override
@@ -26,24 +22,12 @@ public class DemoApplication extends Application {
         super.onCreate();
 
         // Initialize
-        initBranch();
         initAdobeBranch();
-        registerAdobeBranchExtension();
-//        Analytics.setVisitorIdentifier("custom_identifier_123"); // to test custom visitor ID (key: "vid")
-    }
-
-    private void initBranch() {
-        Branch.enableDebugMode();
-
-        // TODO: Revisit.  This is how we should encourage customers to initialize Branch using Branch.
-        // Branch.getAutoInstance(this);
+        Analytics.setVisitorIdentifier("custom_identifier_1234"); // to test custom visitor ID (key: "vid")
     }
 
     private void initAdobeBranch() {
         PrefHelper.Debug("initAdobeBranch()");
-
-        // TODO: Revisit.  We should encourage customers to initialize Branch using Branch.
-        AdobeBranch.getAutoInstance(this);
 
         MobileCore.setApplication(this);
         MobileCore.setLogLevel(LoggingMode.DEBUG);
@@ -54,9 +38,9 @@ public class DemoApplication extends Application {
             Identity.registerExtension();
             Lifecycle.registerExtension();
             Signal.registerExtension();
+            AdobeBranchExtension.registerExtension(this, true);
             MobileCore.start(new AdobeCallback () {
-                @Override
-                public void call(Object o) {
+                @Override public void call(Object o) {
                     MobileCore.configureWithAppID(ADOBE_APP_ID);
                 }
             });
@@ -64,18 +48,4 @@ public class DemoApplication extends Application {
             PrefHelper.Debug("InitException: " + e.getLocalizedMessage());
         }
     }
-
-    private void registerAdobeBranchExtension() {
-        ExtensionErrorCallback<ExtensionError> errorCallback = new ExtensionErrorCallback<ExtensionError>() {
-            @Override
-            public void error(final ExtensionError extensionError) {
-                PrefHelper.Debug(String.format("An error occurred while registering the AdobeBranchExtension %d %s", extensionError.getErrorCode(), extensionError.getErrorName()));
-            }
-        };
-
-        if (!MobileCore.registerExtension(AdobeBranchExtension.class, errorCallback)) {
-            PrefHelper.Debug("Failed to register the AdobeBranchExtension extension");
-        }
-    }
-
 }

--- a/AdobeBranchExtension/build.gradle
+++ b/AdobeBranchExtension/build.gradle
@@ -34,12 +34,12 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // Branch
-    api 'io.branch.sdk.android:library:4.2.0'
-    javadocDeps 'io.branch.sdk.android:library:4.2.0'
+    api 'io.branch.sdk.android:library:4.3.2'
+    javadocDeps 'io.branch.sdk.android:library:4.3.2'
 
     // Adobe
     androidTestImplementation 'com.adobe.marketing.mobile:userprofile:1.0.1'
-    implementation 'com.adobe.marketing.mobile:sdk-core:1.4.6'
+    implementation 'com.adobe.marketing.mobile:sdk-core:1.5.0'
 }
 
 //------------- Javadocs ---------------//

--- a/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/TestApplication.java
+++ b/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/TestApplication.java
@@ -4,8 +4,6 @@ import android.app.Application;
 import android.util.Log;
 
 import com.adobe.marketing.mobile.AdobeCallback;
-import com.adobe.marketing.mobile.ExtensionError;
-import com.adobe.marketing.mobile.ExtensionErrorCallback;
 import com.adobe.marketing.mobile.Identity;
 import com.adobe.marketing.mobile.InvalidInitException;
 import com.adobe.marketing.mobile.Lifecycle;
@@ -16,7 +14,6 @@ import com.adobe.marketing.mobile.UserProfile;
 
 import io.branch.adobe.extension.AdobeBranch;
 import io.branch.adobe.extension.AdobeBranchExtension;
-import io.branch.referral.*;
 
 public class TestApplication extends Application {
     private static final String TAG = "Branch::TestApplication::";
@@ -27,13 +24,7 @@ public class TestApplication extends Application {
         super.onCreate();
 
         // Initialize
-        initBranch();
         initAdobeBranch();
-        registerAdobeBranchExtension();
-    }
-
-    private void initBranch() {
-        Branch.enableDebugMode();
     }
 
     private void initAdobeBranch() {
@@ -45,6 +36,7 @@ public class TestApplication extends Application {
         MobileCore.setLogLevel(LoggingMode.VERBOSE);
 
         try {
+            AdobeBranchExtension.registerExtension(this, true);
             UserProfile.registerExtension();
             Identity.registerExtension();
             Lifecycle.registerExtension();
@@ -59,20 +51,4 @@ public class TestApplication extends Application {
             Log.e(TAG, "InitException", e);
         }
     }
-
-    private void registerAdobeBranchExtension() {
-        MobileCore.setApplication(this);
-
-        ExtensionErrorCallback<ExtensionError> errorCallback = new ExtensionErrorCallback<ExtensionError>() {
-            @Override
-            public void error(final ExtensionError extensionError) {
-                Log.e(TAG, String.format("An error occurred while registering the AdobeBranchExtension %d %s", extensionError.getErrorCode(), extensionError.getErrorName()));
-            }
-        };
-
-        if (!MobileCore.registerExtension(AdobeBranchExtension.class, errorCallback)) {
-            Log.e(TAG, "Failed to register the AdobeBranchExtension extension");
-        }
-    }
-
 }

--- a/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranch.java
+++ b/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranch.java
@@ -3,6 +3,7 @@ package io.branch.adobe.extension;
 import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
+import android.os.Handler;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
@@ -33,6 +34,7 @@ public class AdobeBranch {
 
     // Package Private Configuration Event
     static final String KEY_APICONFIGURATION = "branch_api_configuration";
+    static final int INIT_SESSION_DELAY_MILLIS = 750;
 
     /**
      * Singleton method to return the pre-initialized, or newly initialize and return, a singleton
@@ -47,19 +49,47 @@ public class AdobeBranch {
     }
 
     /**
-     * <p>Initializes a session with the Branch API.
+     * <p>Initializes Branch session after the default 750 millisecond delay needed to collect Adobe IDs.
+     * To initialize without delay, use initSession(callback, data, activity, delay) passing in 0 as the delay parameter.
+     *
      * @param callback A listener that will be called following successful (or unsuccessful)
      *                 initialization of the session with the Branch API.
      * @param data     A {@link  Uri} variable containing the details of the source link that
      *                 led to this initialization action.
      * @param activity The calling {@link Activity} for context.
-     * @return A {@link Boolean} value that will return <i>false</i> if the supplied <i>data</i>
-     * parameter cannot be handled successfully - i.e. is not of a valid URI format.
+     * @return         A {@link Boolean} value that will return <i>false</i> if the supplied <i>data</i>
+     *                 parameter cannot be handled successfully - i.e. is not of a valid URI format.
      */
     public static boolean initSession(Branch.BranchReferralInitListener callback, Uri data, Activity activity) {
-        Branch branch = Branch.getInstance();
+        return initSession(callback, data, activity, INIT_SESSION_DELAY_MILLIS);
+    }
+
+    /**
+     * <p>Initializes Branch session after the chosen delay in milliseconds (needed to collect Adobe IDs).
+     * To initialize without delay pass 0 as the delay parameter.
+     *
+     * @param callback A listener that will be called following successful (or unsuccessful)
+     *                 initialization of the session with the Branch API.
+     * @param data     A {@link  Uri} variable containing the details of the source link that
+     *                 led to this initialization action.
+     * @param activity The calling {@link Activity} for context.
+     * @param delay    An {@link Integer} to set session initialization delay in millis (delay is needed to collect Adobe IDs).
+     * @return         A {@link Boolean} value that will return <i>false</i> if the supplied <i>data</i>
+     *                 parameter cannot be handled successfully - i.e. is not of a valid URI format.
+     */
+    public static boolean initSession(final Branch.BranchReferralInitListener callback, final Uri data, final Activity activity, int delay) {
+        final Branch branch = Branch.getInstance();
         if (branch != null) {
-            return branch.initSession(callback, data, activity);
+            if (delay == 0) {
+                branch.initSession(callback, data, activity);
+            } else {
+                new Handler().postDelayed(new Runnable() {
+                    @Override public void run() {
+                        branch.initSession(callback, data, activity);
+                    }
+                }, delay);
+            }
+            return true;
         }
         return false;
     }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,9 @@
 # Adobe Branch SDK Extension change log
+- v1.2.0
+  * _*Master Release*_ - November 19, 2019
+  * Minor: delay session initialization to allow enough time to collect Adobe IDs
+  * Clean up extension registration flow
+
 - v1.1.3
   * _*Master Release*_ - November 19, 2019
   * Patch: automatically pick up all Adobe IDs and pass it to Branch

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=1.1.3
-VERSION_CODE=010103
+VERSION_NAME=1.1.4
+VERSION_CODE=010104
 GROUP=io.branch.sdk.android
 
 POM_NAME=Branch Adobe Android SDK

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=1.1.4
-VERSION_CODE=010104
+VERSION_NAME=1.2.0
+VERSION_CODE=010200
 GROUP=io.branch.sdk.android
 
 POM_NAME=Branch Adobe Android SDK


### PR DESCRIPTION
INTENG-9038 - Adobe Launch-Android SDK v.1.1.3 configuration unclear to automatically pick up Adobe ID's

## Reference
https://branch.atlassian.net/browse/INTENG-9038

## Description
The only reason my previous "fix" worked was because we used the old SDK, so it waited some seconds before initialization to receive the referrer broadcast. Added a default 750 millisecond delay to Branch session initialization. Clients can override this value or set it to zero (e.g. for intra-app linking).

## Testing Instructions
Run AdobeBranchExample

## Risk Assessment [`HIGH | MEDIUM | LOW`]
MEDIUM

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

**You can only merge once all of these are checked off!**

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
