### PR TITLE
Sdk 874/broken auto init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 gradle/
 gradlew
 gradlew.bat
+
+AdobeBranchExample/.idea
+AdobeBranchExample/local.properties

--- a/AdobeBranchExample/src/main/AndroidManifest.xml
+++ b/AdobeBranchExample/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         <activity
             android:name=".ProductActivity"
             android:label="@string/app_name"
+            android:launchMode="singleTask"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -25,9 +26,7 @@
 
             <!-- Branch URI Scheme -->
             <intent-filter>
-                <data
-                    android:host="open"
-                    android:scheme="adobe-branch" />
+                <data android:scheme="adobe-branch" />
 
                 <action android:name="android.intent.action.VIEW" />
 

--- a/AdobeBranchExample/src/main/java/io/branch/adobe/demo/ProductActivity.java
+++ b/AdobeBranchExample/src/main/java/io/branch/adobe/demo/ProductActivity.java
@@ -2,7 +2,7 @@ package io.branch.adobe.demo;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
+import android.text.TextUtils;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListAdapter;
@@ -57,13 +57,14 @@ public class ProductActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        initBranchSession();
+        AdobeBranch.initSession(branchInitSessionCallback, getIntent().getData(), this);
     }
 
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         this.setIntent(intent);
+        AdobeBranch.initSession(branchInitSessionCallback, getIntent().getData(), this, 0);
     }
 
     private void initList() {
@@ -88,16 +89,16 @@ public class ProductActivity extends AppCompatActivity {
         }
     }
 
-    private void initBranchSession() {
-        AdobeBranch.initSession(new Branch.BranchReferralInitListener() {
+    private Branch.BranchReferralInitListener branchInitSessionCallback = new Branch.BranchReferralInitListener() {
             @Override
             public void onInitFinished(JSONObject referringParams, BranchError error) {
+                PrefHelper.Debug("initBranchSession, referringParams = " + referringParams + ", error = " + error);
                 if (referringParams == null) return;
                 try {
                     // You would think that there was an easier way to figure this out than looking at LinkProperties code
                     if (referringParams.has("+clicked_branch_link") && referringParams.getBoolean("+clicked_branch_link")) {
                         String idString = referringParams.optString(SwagActivity.SWAG_ID);
-                        if (idString != null) {
+                        if (!TextUtils.isEmpty(idString)) {
                             int swagId = Integer.parseInt(idString);
 
                             // Launch the Swag Activity
@@ -111,8 +112,8 @@ public class ProductActivity extends AppCompatActivity {
                     // internal error; id is not a number.
                 }
             }
-        }, getIntent().getData(), this);
-    }
+        };
+
 
     private void shareProduct() {
         BranchUniversalObject buo = new BranchUniversalObject();

--- a/AdobeBranchExample/src/main/java/io/branch/adobe/demo/ProductActivity.java
+++ b/AdobeBranchExample/src/main/java/io/branch/adobe/demo/ProductActivity.java
@@ -64,7 +64,7 @@ public class ProductActivity extends AppCompatActivity {
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         this.setIntent(intent);
-        AdobeBranch.initSession(branchInitSessionCallback, getIntent().getData(), this, 0);
+        AdobeBranch.reInitSession(this, branchInitSessionCallback);
     }
 
     private void initList() {

--- a/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranch.java
+++ b/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranch.java
@@ -43,8 +43,6 @@ public class AdobeBranch {
      * @return An initialized {@link Branch} object
      */
     public static Branch getAutoInstance(@NonNull Context context) {
-        BranchUtil.setPluginType(BranchUtil.PluginType.AdobeLaunch);
-        BranchUtil.setPluginVersion(BuildConfig.VERSION_NAME);
         return Branch.getAutoInstance(context);
     }
 
@@ -80,11 +78,13 @@ public class AdobeBranch {
     public static boolean initSession(final Branch.BranchReferralInitListener callback, final Uri data, final Activity activity, int delay) {
         final Branch branch = Branch.getInstance();
         if (branch != null) {
+            BranchUtil.setPluginType(BranchUtil.PluginType.AdobeLaunch);// prevents early auto-initialization
             if (delay == 0) {
                 branch.initSession(callback, data, activity);
             } else {
                 new Handler().postDelayed(new Runnable() {
                     @Override public void run() {
+                        BranchUtil.setPluginType(null);// re-enables auto-initialization for when app is launched from recent apps list
                         branch.initSession(callback, data, activity);
                     }
                 }, delay);

--- a/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranch.java
+++ b/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranch.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import io.branch.referral.Branch;
 import io.branch.referral.BranchUtil;
+import io.branch.referral.Defines;
 
 /**
  * AdobeBranch Extension.
@@ -89,6 +90,21 @@ public class AdobeBranch {
                     }
                 }, delay);
             }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * ReInitialize session. Called from onNewIntent, will only reInitialize if the intent contains a boolean extra "branch_force_new_session"=true
+     */
+    public static boolean reInitSession(@NonNull Activity activity, Branch.BranchReferralInitListener callback) {
+        Branch branch = Branch.getInstance();
+        if (branch != null && branch.reInitSession(activity, callback)) {
+            // this ensures that if user intra-app links from SomeActivity to LauncherActivity,
+            // and both, initSession and reInitSession, are used in LauncherActivity, then only the
+            // reInitSession callback returns referring params while the other one returns error, "SDK already initialized".
+            activity.getIntent().removeExtra(Defines.Jsonkey.ForceNewBranchSession.getKey());
             return true;
         }
         return false;


### PR DESCRIPTION
## Reference
Auto-session initialization broken on Adobe Launch Android
https://branch.atlassian.net/browse/SDK-874

## Description
To pick up Adobe IDs we need to delay session initialization. However if we do so, self initialization happens first and, by the time user calls initSession, SDK calls back with "Session already initialized" error. So we disable session self-initialization by setting a plugin type.

However, Adobe Launch SDK is not like other plugins, it's lifecycle is the same as Android's, so there isn't another lifecycle method that follows Android's onActivityResume (from which clients could initialize the session themselves). This means that when launching the app from recent apps list, if the app user was last seen on NonLauncherActivity, SDK will never initialize session.

We fix this resetting the plugin type to null when delay is over and user's initSession method is about to be called.

## Testing Instructions
Run Adobe Branch Example.

## Risk Assessment [`HIGH | MEDIUM | LOW`]
LOW

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

**You can only merge once all of these are checked off!**

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
