### PR TITLE
Sdk 914/improve initialization delay

### DIFF
--- a/AdobeBranchExample/build.gradle
+++ b/AdobeBranchExample/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // Adobe Branch Extension
-    implementation project(path: ':AdobeBranchExtension')
+    api project(path: ':AdobeBranchExtension')
 
     // Adobe
     implementation 'com.adobe.marketing.mobile:analytics:1.+'

--- a/AdobeBranchExample/src/main/AndroidManifest.xml
+++ b/AdobeBranchExample/src/main/AndroidManifest.xml
@@ -42,10 +42,10 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="adobe-branch.app.link"
+                    android:host="bl7v1.app.link"
                     android:scheme="https" />
                 <data
-                    android:host="adobe-branch-alternate.app.link"
+                    android:host="bl7v1-alternate.app.link"
                     android:scheme="https" />
             </intent-filter>
         </activity>
@@ -57,7 +57,7 @@
         <!-- Branch init -->
         <meta-data
             android:name="io.branch.sdk.BranchKey"
-            android:value="key_live_nbB0KZ4UGOKaHEWCjQI2ThncEAeRJmhy" />
+            android:value="key_live_dhNKlG7lVcfcDbrLi0p20hdjrEhvJKHz" />
 
     </application>
 

--- a/AdobeBranchExample/src/main/java/io/branch/adobe/demo/ProductActivity.java
+++ b/AdobeBranchExample/src/main/java/io/branch/adobe/demo/ProductActivity.java
@@ -11,11 +11,6 @@ import android.widget.ListView;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
-import com.adobe.marketing.mobile.AdobeCallback;
-import com.adobe.marketing.mobile.Analytics;
-import com.adobe.marketing.mobile.Identity;
-import com.adobe.marketing.mobile.MobileCore;
-import com.adobe.marketing.mobile.VisitorID;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import org.json.JSONException;

--- a/AdobeBranchExtension/build.gradle
+++ b/AdobeBranchExtension/build.gradle
@@ -16,10 +16,9 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFile('proguard-rules.pro')
         }
     }
-
 }
 
 configurations {
@@ -34,12 +33,16 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // Branch
-    api 'io.branch.sdk.android:library:4.3.2'
-    javadocDeps 'io.branch.sdk.android:library:4.3.2'
+    api 'io.branch.sdk.android:library:5.0.1'
+    javadocDeps 'io.branch.sdk.android:library:5.0.1'
+    implementation ('com.google.android.gms:play-services-ads-identifier:17.0.0')
+    // for Huawei devices without GMS, adding it requires bumping up min api level to 19 though, so we
+    // leave it up to the client to add it following Branch documentation here: https://help.branch.io/developers-hub/docs/android-basic-integration
+    //implementation 'com.huawei.hms:ads-identifier:3.4.28.305'
 
     // Adobe
-    androidTestImplementation 'com.adobe.marketing.mobile:userprofile:1.0.1'
-    implementation 'com.adobe.marketing.mobile:sdk-core:1.5.0'
+    androidTestImplementation 'com.adobe.marketing.mobile:userprofile:1.1.0'
+    implementation 'com.adobe.marketing.mobile:sdk-core:1.5.4'
 }
 
 //------------- Javadocs ---------------//

--- a/AdobeBranchExtension/proguard-rules.pro
+++ b/AdobeBranchExtension/proguard-rules.pro
@@ -1,21 +1,6 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Branch looks up aaid via refelection
+-keep class com.google.android.gms.** { *; }
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# for Huawei devices without GMS (Branch looks up oaid via refelection)
+#-keep class com.huawei.hms.ads.** { *; }
+#-keep interface com.huawei.hms.ads.** { *; }

--- a/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranch.java
+++ b/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranch.java
@@ -3,8 +3,6 @@ package io.branch.adobe.extension;
 import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
-import android.os.Build;
-import android.os.Handler;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
@@ -16,12 +14,8 @@ import java.util.List;
 import java.util.Map;
 
 import io.branch.referral.Branch;
-import io.branch.referral.BranchUtil;
-import io.branch.referral.BuildConfig;
-import io.branch.referral.Defines;
-import io.branch.referral.PrefHelper;
 
-import static android.preference.PreferenceManager.getDefaultSharedPreferences;
+import static io.branch.adobe.extension.AdobeBranchExtension.PASSED_ADOBE_IDS_TO_BRANCH;
 
 /**
  * AdobeBranch Extension.
@@ -65,7 +59,7 @@ public class AdobeBranch {
      *                 parameter cannot be handled successfully - i.e. is not of a valid URI format.
      */
     public static boolean initSession(Branch.BranchReferralInitListener callback, Uri data, Activity activity) {
-        return initSession(callback, data, activity, INIT_SESSION_DELAY_MILLIS);
+        return initSessionInternal(callback, data, activity);
     }
 
     /**
@@ -83,6 +77,12 @@ public class AdobeBranch {
      */
     public static boolean initSession(final Branch.BranchReferralInitListener callback, final Uri data, final Activity activity, int delay) {
         Branch.sessionBuilder(activity).withCallback(callback).withData(data).withDelay(delay).init();
+        return true;
+    }
+
+    static boolean initSessionInternal(final Branch.BranchReferralInitListener callback, final Uri data, final Activity activity) {
+        Branch.sessionBuilder(activity).withCallback(callback).withData(data).withDelay(
+                PASSED_ADOBE_IDS_TO_BRANCH.get() ? 0 : INIT_SESSION_DELAY_MILLIS).init();
         return true;
     }
 

--- a/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
+++ b/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.branch.referral.Branch;
 import io.branch.referral.PrefHelper;
@@ -45,6 +46,7 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
     static final String IDENTITY_ID = "mid";
     static final String ANALYTICS_VISITOR_ID = "vid";
     static final String ANALYTICS_TRACKING_ID = "aid";
+    static AtomicBoolean PASSED_ADOBE_IDS_TO_BRANCH = new AtomicBoolean(false);
 
     private List<AdobeBranch.EventTypeSource> apiWhitelist;
 
@@ -219,6 +221,7 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
                 }
                 if (IDENTITY_ID.equals(key) || ANALYTICS_VISITOR_ID.equals(key) || ANALYTICS_TRACKING_ID.equals(key)) {
                     // we received at least one, non-empty adobe id
+                    PASSED_ADOBE_IDS_TO_BRANCH.set(true);
                     Branch.getInstance().removeSessionInitializationDelay();
                 }
             }

--- a/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
+++ b/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
@@ -42,6 +42,10 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
     static final String BRANCH_CONFIGURATION_EVENT = "io.branch.eventtype.configuration";
     static final String BRANCH_EVENT_SOURCE = "io.branch.eventsource.configurecontent";
 
+    static final String IDENTITY_ID = "mid";
+    static final String ANALYTICS_VISITOR_ID = "vid";
+    static final String ANALYTICS_TRACKING_ID = "aid";
+
     private List<AdobeBranch.EventTypeSource> apiWhitelist;
 
     public AdobeBranchExtension(final ExtensionApi extensionApi) {
@@ -56,7 +60,7 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
     @SuppressWarnings("WeakerAccess")
     public static void registerExtension(@NonNull Context context, boolean debugMode) {
         if (debugMode) {
-            Branch.enableDebugMode();
+            Branch.enableLogging();
         }
         AdobeBranch.getAutoInstance(context.getApplicationContext());
         boolean successfulRegistration = MobileCore.registerExtension(AdobeBranchExtension.class, new ExtensionErrorCallback<ExtensionError>() {
@@ -174,8 +178,8 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
 
     /**
      * Handle "shared state change" events by checking if the owner of a given event is one of the
-     * extensions that keeps track of Adobe IDs (e.g. Identity/Analytics). If so, get the shared state of
-     * that extension and retrieve the Adobe IDs if they are present, then pass the IDs to Branch.
+     * extensions that keeps track of Adobe IDs (e.g. from Identity/Analytics extensions). If so, get
+     * the shared state of that extension and retrieve the Adobe IDs if they are present, then pass the IDs to Branch.
      * https://aep-sdks.gitbook.io/docs/resources/building-mobile-extensions/requesting-a-shared-state
      * @param event Adobe Event
      */
@@ -186,31 +190,36 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
             Object stateowner = event.getEventData().get(ADOBE_SHARED_STATE_EVENT_OWNER_KEY);
             if (ADOBE_ANALYTICS_EXTENSION.equals(stateowner)) {
                 extensionSharedState = getApi().getSharedEventState(ADOBE_ANALYTICS_EXTENSION, event, this);
-                PrefHelper.Debug(String.format("analytics extension shared state = %s", new JSONObject(extensionSharedState)));
             } else if (ADOBE_IDENTITY_EXTENSION.equals(stateowner)) {
                 extensionSharedState = getApi().getSharedEventState(ADOBE_IDENTITY_EXTENSION, event, this);
-                PrefHelper.Debug(String.format("identity extension shared state = %s", new JSONObject(extensionSharedState)));
             }
             for (Map.Entry<String, Object> entry :extensionSharedState.entrySet()) {
+                PrefHelper.Debug(String.format("identity extension shared state = %s", new JSONObject(extensionSharedState)));
 
                 Object value = entry.getValue();
                 if (value == null) continue;
                 String valueAsString = value.toString();
                 if (TextUtils.isEmpty(valueAsString)) continue;
 
-                switch (entry.getKey()) {
-                    case "mid":
+                final String key = entry.getKey();
+                switch (key) {
+                    case IDENTITY_ID:
                         // pass Adobe Experience Cloud ID (https://app.gitbook.com/@aep-sdks/s/docs/using-mobile-extensions/mobile-core/identity/identity-api-reference#getExperienceCloudIdTitle)
                         branch.setRequestMetadata("$marketing_cloud_visitor_id", valueAsString);
                         break;
-                    case "vid":
+                    case ANALYTICS_VISITOR_ID:
                         // pass Adobe Custom Visitor ID (https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-analytics/analytics-api-reference#getvisitoridentifier)
                         branch.setRequestMetadata("$analytics_visitor_id", valueAsString);
                         break;
-                    case "aid":
+                    case ANALYTICS_TRACKING_ID:
                         // pass Adobe Tracking ID (https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-analytics/analytics-api-reference#gettrackingidentifier)
+                        // if MARKETING_CLOUD_VISITOR_ID is set this will always be null unless the Adobe Launch client set a grace period to support both IDs (https://docs.adobe.com/content/help/en/id-service/using/implementation/setup-analytics.html#:~:text=Grace%20periods%20can%20run%20for,a%20grace%20period%20if%20required.&text=You%20need%20a%20grace%20period,the%20same%20Analytics%20report%20suite.)
                         branch.setRequestMetadata("$adobe_visitor_id", valueAsString);
                         break;
+                }
+                if (IDENTITY_ID.equals(key) || ANALYTICS_VISITOR_ID.equals(key) || ANALYTICS_TRACKING_ID.equals(key)) {
+                    // we received at least one, non-empty adobe id
+                    Branch.getInstance().removeSessionInitializationDelay();
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url 'http://developer.huawei.com/repo/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.1'
@@ -19,6 +20,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'http://developer.huawei.com/repo/' }
     }
 }
 


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/SDK-914

## Description
- remove hardcoded session initialization wait time of 750 millis
- utilize conditional delay baked into the init session builder.
- removed registering plugin type because the Android SDK currently blocks self-initialization if it detects any plugin being used, the old implementation used the plugin type as a hack to not self-initialize and wait for Adobe IDs. The old implementation was bad anyway because only fresh sessions contained the plugin type (launching from recent apps tray would have not contained plugin type in the payload)
- once all relevant plugins start using the built in session initialization delay mechanism, then we can remove the SDK logic preventing self-initialization for all plugins, then we can add back in `registerPlugin` here - unfortunately this means a gap in plugin type data :(
- There was one more hack init reInitSession that I removed because SDK handles that case now too
- Note also that we only wait for one adobe ID and allow the session initialization to proceed. When running the sample app, this behavior seemed fine even when two adobe ids are used (both were reported) because our SDK actually takes some time to fire the open request (e.g. waits for GAID), however even if it fired earlier, we don't have any way of knowing which of the Adobe IDs _will_ be present, so as long as we have at least one, we move on. cc @derrick-branch we should confirm this is OK logic with Adobe tomorrow

## Testing Instructions
run example app, observe logs, when activity is started, take note of the timestamp on that log entry (that's when we started initSession), then observe in the logs when the actual network run request is fired, make sure the time diff is less than 1 second.

## Risk Assessment [`HIGH | MEDIUM | LOW`]
MEDIUM

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

**You can only merge once all of these are checked off!**

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
