### PR TITLE
INTENG-10910/pickup adobe event names correctly

### DIFF
--- a/AdobeBranchExample/src/main/java/io/branch/adobe/demo/SwagActivity.java
+++ b/AdobeBranchExample/src/main/java/io/branch/adobe/demo/SwagActivity.java
@@ -9,7 +9,6 @@ import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
-import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.ExtensionError;
 import com.adobe.marketing.mobile.ExtensionErrorCallback;
 import com.adobe.marketing.mobile.MobileCore;
@@ -138,31 +137,26 @@ public class SwagActivity extends AppCompatActivity implements View.OnClickListe
     private void doPurchase(View view) {
         Long timestamp = System.currentTimeMillis()/1000;
 
-        Map<String, Object> eventData = new HashMap<>();
+        Map<String, String> eventData = new HashMap<>();
         eventData.put(AdobeBranch.KEY_AFFILIATION, "Branch Metrics Company Store");
         eventData.put(AdobeBranch.KEY_COUPON, "SATURDAY NIGHT SPECIAL");
         eventData.put(AdobeBranch.KEY_CURRENCY, "USD");
         eventData.put(AdobeBranch.KEY_DESCRIPTION, mSwagModel.getDescription());
-        eventData.put(AdobeBranch.KEY_REVENUE, mSwagModel.getPrice());
-        eventData.put(AdobeBranch.KEY_SHIPPING, 0.99);
-        eventData.put(AdobeBranch.KEY_TAX, (mSwagModel.getPrice() * 0.077));
+        eventData.put(AdobeBranch.KEY_REVENUE, String.valueOf(mSwagModel.getPrice()));
+        eventData.put(AdobeBranch.KEY_SHIPPING, "0.99");
+        eventData.put(AdobeBranch.KEY_TAX, String.valueOf(mSwagModel.getPrice() * 0.077));
         eventData.put(AdobeBranch.KEY_TRANSACTION_ID, UUID.randomUUID().toString());
 
         eventData.put("category", "Arts & Entertainment");
-        eventData.put("product_id", mSwagModel.getId());
+        eventData.put("product_id", String.valueOf(mSwagModel.getId()));
         eventData.put("sku", "sku-be-doo");
         eventData.put("timestamp", timestamp.toString());
 
         eventData.put("custom1", "Custom Data 1");
         eventData.put("custom2", "Custom Data 2");
 
-        Event newEvent = new Event.Builder("PURCHASE",
-                "com.adobe.eventType.generic.track",
-                "com.adobe.eventSource.requestContent")
-                .setEventData(eventData).build();
-
         // dispatch the analytics event
-        MobileCore.dispatchEvent(newEvent, this);
+        MobileCore.trackAction("PURCHASE", eventData);
 
         showSnackbar(view, "Thank you for your purchase of " + mSwagModel.getTitle() + "!");
     }
@@ -173,20 +167,12 @@ public class SwagActivity extends AppCompatActivity implements View.OnClickListe
     private void doAddToCart(View view) {
         Long timestamp = System.currentTimeMillis()/1000;
 
-        Map<String, Object> eventData = new HashMap<>();
+        Map<String, String> eventData = new HashMap<>();
         eventData.put(AdobeBranch.KEY_DESCRIPTION, mSwagModel.getDescription());
-        eventData.put(AdobeBranch.KEY_REVENUE, mSwagModel.getPrice());
-
-        eventData.put("product_id", mSwagModel.getId());
+        eventData.put(AdobeBranch.KEY_REVENUE, String.valueOf(mSwagModel.getPrice()));
+        eventData.put("product_id", String.valueOf(mSwagModel.getId()));
         eventData.put("timestamp", timestamp.toString());
-
-        Event newEvent = new Event.Builder("ADD_TO_CART",
-                "com.adobe.eventType.generic.track",
-                "com.adobe.eventSource.requestContent")
-                .setEventData(eventData).build();
-
-        // dispatch the analytics event
-        MobileCore.dispatchEvent(newEvent, this);
+        MobileCore.trackState("ADD_TO_CART", eventData);
 
         showSnackbar(view, mSwagModel.getTitle() + " added to your shopping cart");
     }

--- a/AdobeBranchExtension/build.gradle
+++ b/AdobeBranchExtension/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // Branch
-    api 'io.branch.sdk.android:library:5.0.1'
-    javadocDeps 'io.branch.sdk.android:library:5.0.1'
+    api 'io.branch.sdk.android:library:5.0.3'
+    javadocDeps 'io.branch.sdk.android:library:5.0.3'
     implementation ('com.google.android.gms:play-services-ads-identifier:17.0.0')
     // for Huawei devices without GMS, adding it requires bumping up min api level to 19 though, so we
     // leave it up to the client to add it following Branch documentation here: https://help.branch.io/developers-hub/docs/android-basic-integration

--- a/AdobeBranchExtension/build.gradle
+++ b/AdobeBranchExtension/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // Branch
@@ -41,8 +42,9 @@ dependencies {
     //implementation 'com.huawei.hms:ads-identifier:3.4.28.305'
 
     // Adobe
-    androidTestImplementation 'com.adobe.marketing.mobile:userprofile:1.1.0'
-    implementation 'com.adobe.marketing.mobile:sdk-core:1.5.4'
+    androidTestImplementation 'com.adobe.marketing.mobile:analytics:1.+'
+    androidTestImplementation 'com.adobe.marketing.mobile:userprofile:1.+'
+    implementation 'com.adobe.marketing.mobile:sdk-core:1.+'
 }
 
 //------------- Javadocs ---------------//

--- a/AdobeBranchExtension/src/androidTest/AndroidManifest.xml
+++ b/AdobeBranchExtension/src/androidTest/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
     <application
         android:name=".TestApplication" >
+        <activity android:name=".MockActivity" />
 
         <!-- The Branch Key for testing.  Do not use these keys for production applications. -->
         <meta-data

--- a/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeBranchTest.java
+++ b/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeBranchTest.java
@@ -24,7 +24,7 @@ public class AdobeBranchTest {
 
     @Before
     public void setUp() {
-        Branch.enableDebugMode();
+        Branch.enableLogging();
         mContext = InstrumentationRegistry.getContext();
     }
 

--- a/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeBranchTest.java
+++ b/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeBranchTest.java
@@ -1,47 +1,97 @@
 package io.branch.adobe.extension.test;
 
+import android.app.Application;
 import android.content.Context;
 
-import androidx.test.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+
+import com.adobe.marketing.mobile.AdobeCallback;
+import com.adobe.marketing.mobile.Analytics;
+import com.adobe.marketing.mobile.Identity;
+import com.adobe.marketing.mobile.InvalidInitException;
+import com.adobe.marketing.mobile.Lifecycle;
+import com.adobe.marketing.mobile.LoggingMode;
+import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.Signal;
+import com.adobe.marketing.mobile.UserProfile;
 
 import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
 
+import io.branch.adobe.extension.AdobeBranchExtension;
 import io.branch.referral.Branch;
+import io.branch.referral.PrefHelper;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
 /**
  * Base Instrumented test, which will execute on an Android device.
  */
 @RunWith(AndroidJUnit4.class)
 public class AdobeBranchTest {
+    private static final String TAG = "AdobeBranchTest";
+    private static final String ADOBE_APP_ID = "d10f76259195/b0503e1a5dce/launch-9948a3b3a89d-development";
+    private Application app;
     private Context mContext;
+
+    @Rule
+    public ActivityTestRule<MockActivity> mActivityRule = new ActivityTestRule<>(MockActivity.class);
 
     @Before
     public void setUp() {
-        Branch.enableLogging();
-        mContext = InstrumentationRegistry.getContext();
+        app = mActivityRule.getActivity().getApplication();
+        mContext = getInstrumentation().getContext();
+
+        initAdobeBranch();
+    }
+
+    private void initAdobeBranch() {
+        PrefHelper.Debug("AdobeBranchTest.initAdobeBranch()");
+
+        MobileCore.setApplication(app);
+        MobileCore.setLogLevel(LoggingMode.DEBUG);
+
+        try {
+            Analytics.registerExtension();
+            UserProfile.registerExtension();
+            Identity.registerExtension();
+            Lifecycle.registerExtension();
+            Signal.registerExtension();
+            AdobeBranchExtension.registerExtension(app, true);
+            MobileCore.start(new AdobeCallback() {
+                @Override public void call(Object o) {
+                    MobileCore.configureWithAppID(ADOBE_APP_ID);
+                }
+            });
+        } catch (InvalidInitException e) {
+            PrefHelper.Debug("AdobeBranchTest.InvalidInitException: " + e.getLocalizedMessage());
+        }
     }
 
     @After
     public void tearDown() {
-        mContext = null;
         shutdownBranch();
+        app = null;
+        mContext = null;
     }
 
     @Test
     public void testAppContext() {
         // Context of the app under test.
-        Assert.assertNotNull(getTestContext());
+        Assert.assertNotNull(mContext);
     }
 
-    Context getTestContext() {
-        return mContext;
+    @Test
+    public void testBranchInstance() {
+        // Context of the app under test.
+        Assert.assertNotNull(Branch.getInstance());
     }
 
     private void shutdownBranch() {
@@ -53,6 +103,4 @@ public class AdobeBranchTest {
             Assert.fail();
         }
     }
-
-
 }

--- a/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeEventTest.java
+++ b/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/AdobeEventTest.java
@@ -1,9 +1,7 @@
 package io.branch.adobe.extension.test;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import android.util.Log;
 
-import com.adobe.marketing.mobile.AdobeCallback;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.ExtensionError;
 import com.adobe.marketing.mobile.ExtensionErrorCallback;
@@ -13,113 +11,218 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.branch.adobe.extension.AdobeBranch;
 import io.branch.referral.Branch;
+import io.branch.referral.PrefHelper;
+import io.branch.referral.util.BRANCH_STANDARD_EVENT;
 
 /**
- * Adobe Event Testing.
- * Note that this isn't your typical unit test suite, because Adobe doesn't actually call back to
- * if the request succeeded or not, just that it had sufficient information to proceed.  We have
- * taken the path of using the ADB logs to do actual validation, and only doing superficial validation
- * during the unit tests themselves.
+ * Adobe Event Testing. We use reflection to retrieve Branch.instrumentationExtraData_ to see if the event
+ * was registered and fired on the Branch side. This isn't a typical test suite and the test pass individually
+ * but there seems to co-dependencies, so they don't pass when we run them altogether. Todo fix the co-dependencies.
  */
 @RunWith(AndroidJUnit4.class)
 public class AdobeEventTest extends AdobeBranchTest {
-    private static final String TAG = "AdobeBranchTest";
+    private static final String TAG = "AdobeEventTest";
+    Map<String, Object> randomData = new HashMap<String, Object>() {{
+        put("foo", "bar");
+        put("foo1", 1);
+    }};
 
-    @Override
-    public void setUp() {
-        super.setUp();
-        Assert.assertNotNull(Branch.getInstance(getTestContext()));
+    @Test
+    public void testTrackCustomState() throws NoSuchFieldException, IllegalAccessException, InterruptedException, InstantiationException {
+        testTrackCustomStateWithExpectation(true);
     }
 
     @Test
-    public void testDispatchEvent() {
-        // Test a standard adobe event.  Logs should show one event sent
-        Event event = new Event.Builder("testDispatchEvent",
-                "com.adobe.eventType.generic.track",
-                "com.adobe.eventSource.requestContent")
-                .build();
-        sendEvent(event);
+    public void testTrackStandardState() throws NoSuchFieldException, IllegalAccessException, InterruptedException, InstantiationException {
+        testTrackStandardStateWithExpectation(true);
     }
 
     @Test
-    public void testWhitelistEvent() {
-        // Test a whitelisted event.  Logs should show two events sent
+    public void testTrackCustomAction() throws NoSuchFieldException, IllegalAccessException, InterruptedException, InstantiationException {
+        testTrackCustomActionWithExpectation(true);
+    }
+
+    @Test
+    public void testTrackStandardAction() throws NoSuchFieldException, IllegalAccessException, InterruptedException, InstantiationException {
+        testTrackStandardActionWithExpectation(true);
+    }
+
+    @Test
+    public void testWhitelistOfExclusivelyCustomTypeAndSourceEvents() throws InterruptedException, IllegalAccessException, NoSuchFieldException, InstantiationException {
+        // define the whitelist
+        Map<String, String> whitelistConfigurations = new HashMap<String, String>() {{
+            put("com.adobe.eventType.generic.track1", "com.adobe.eventSource.requestContent1");// custom type and source events
+            put("io.branch.eventType.generic.track1", "io.branch.eventSource.requestContent1");// custom type and source events
+        }};
+
+        // register the whitelist
         List<AdobeBranch.EventTypeSource> apiWhitelist = new ArrayList<>();
-        apiWhitelist.add(new AdobeBranch.EventTypeSource("com.adobe.eventType.generic.track", "com.adobe.eventSource.requestContent"));
-        apiWhitelist.add(new AdobeBranch.EventTypeSource("io.branch.eventType.generic.track", "io.branch.eventSource.requestContent"));
-
+        for (Map.Entry<String, String> entry : whitelistConfigurations.entrySet()) {
+            apiWhitelist.add(new AdobeBranch.EventTypeSource(entry.getKey(), entry.getValue()));
+        }
         Assert.assertTrue(AdobeBranch.registerAdobeBranchEvents(apiWhitelist));
-        sendWhitelistedEvents("testWhitelistEvent");
+        Thread.sleep(500);
+
+        // test sending this Adobe event of custom type and source, as either custom or standard Branch event depending on that Adobe events name.
+        for (Map.Entry<String, String> entry : whitelistConfigurations.entrySet()) {
+            sendCustomEventOfCustomTypeAndSource(entry.getKey(), entry.getValue(), true);
+            sendStandardEventOfCustomTypeAndSource(entry.getKey(), entry.getValue(), true);
+        }
+        // normal adobe events should fail
+        testTrackStandardActionWithExpectation(false);
+        testTrackCustomActionWithExpectation(false);
+        testTrackStandardStateWithExpectation(false);
+        testTrackCustomStateWithExpectation(false);
     }
 
     @Test
-    public void testEmptyWhitelistEvent() {
-        // Test a whitelisted event.  Logs should show zero events sent
-        List<AdobeBranch.EventTypeSource> apiWhitelist = new ArrayList<>();
+    public void testEmptyWhitelist() throws InterruptedException, IllegalAccessException, NoSuchFieldException, InstantiationException {
+        // register empty whitelist
+        Assert.assertTrue(AdobeBranch.registerAdobeBranchEvents(new ArrayList<AdobeBranch.EventTypeSource>()));
+        Thread.sleep(500);
 
-        Assert.assertTrue(AdobeBranch.registerAdobeBranchEvents(apiWhitelist));
-        sendWhitelistedEvents("testEmptyWhitelistEvent");
+        // test sending Adobe event of custom type and source, should fail
+        sendStandardEventOfCustomTypeAndSource("io.branch.eventType.generic.track1", "io.branch.eventSource.requestContent1", false);
+        // test sending normal Adobe events, should fail
+        testTrackStandardActionWithExpectation(false);
+        testTrackCustomActionWithExpectation(false);
+        testTrackStandardStateWithExpectation(false);
+        testTrackCustomStateWithExpectation(false);
     }
 
     @Test
-    public void testNullWhitelistEvent() {
-        // Test a whitelisted event.  Logs should show a single event sent (default case)
+    public void testNullWhitelist() throws InterruptedException, IllegalAccessException, NoSuchFieldException, InstantiationException {
+        // register empty whitelist
         Assert.assertTrue(AdobeBranch.registerAdobeBranchEvents(null));
-        sendWhitelistedEvents("testEmptyWhitelistEvent");
+        Thread.sleep(1000);
+
+        // test sending Adobe event of custom type and source, should fail
+        sendStandardEventOfCustomTypeAndSource("io.branch.eventType.generic.track1", "io.branch.eventSource.requestContent1", false);
+        // test sending normal Adobe events, should succeed
+        testTrackStandardActionWithExpectation(true);
+        testTrackCustomActionWithExpectation(true);
+        testTrackStandardStateWithExpectation(true);
+        testTrackCustomStateWithExpectation(true);
     }
 
-    // Utility to send a batch of events
-    private void sendWhitelistedEvents(String eventName) {
-        int eventId = 0;
-        Event event = new Event.Builder(eventName + ++eventId,
-                "com.adobe.eventType.generic.track",
-                "com.adobe.eventSource.requestContent")
-                .build();
-        sendEvent(event);
 
-        event = new Event.Builder(eventName + ++eventId,
-                "io.branch.eventType.generic.track",
-                "io.branch.eventSource.requestContent")
-                .build();
-        sendEvent(event);
 
-        event = new Event.Builder(eventName + ++eventId,
-                "com.test.eventType.generic.track",
-                "com.test.eventSource.requestContent")
-                .build();
-        sendEvent(event);
+
+
+
+    // UTILITIES
+
+    protected void sendCustomEventOfCustomTypeAndSource(String type, String source, final boolean branchIsExpectedToRegisterEvent) {
+        Event event = new Event.Builder("testCustomEventOfCustomTypeAndSource", type, source).setEventData(randomData).build();
+        sendEvent(event, branchIsExpectedToRegisterEvent);
     }
 
-    // Utility to test sending a single event to Adobe with a START and END marker
-    private void sendEvent(final Event event) {
-        Log.d(TAG, "sendEvent (START) -- " + event.getName());
+    protected void sendStandardEventOfCustomTypeAndSource(String type, String source, final boolean branchIsExpectedToRegisterEvent) {
+        Event event = new Event.Builder("ADD_TO_CART", type, source).setEventData(randomData).build();
+        sendEvent(event, branchIsExpectedToRegisterEvent);
+    }
 
-        Assert.assertTrue(MobileCore.dispatchEventWithResponseCallback(event,
-            new AdobeCallback<Event>() {
-                @Override
-                public void call(Event eventCopy) {
-                    Assert.assertEquals(event.getName(), eventCopy.getName());
-                }
-            },
-            new ExtensionErrorCallback<ExtensionError>() {
-                @Override
-                public void error(ExtensionError extensionError) {
-                    Assert.fail();
-                }
-            }));
+    // Send a single event to Adobe with a START and END marker (in logs).
+    // Compatible with events of custom type and source, thus uses dispatchEvent rather than MobileCore.trackState/MobileCore.trackAction
+    protected void sendEvent(final Event event, final boolean branchIsExpectedToRegisterEvent) {
+        PrefHelper.Debug("sendEvent (START) -- " + event.getName());
+
+        Assert.assertTrue(MobileCore.dispatchEvent(event,
+                new ExtensionErrorCallback<ExtensionError>() {
+                    @Override
+                    public void error(ExtensionError extensionError) {
+                        Assert.fail();
+                    }
+                }));
 
         // Adobe is asynchronous...  give it a chance to show something in the logs.
         try {
-            Thread.sleep(500);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             Assert.fail();
         }
 
-        Log.d(TAG, "sendEvent (END)  -- " + event.getName());
+        // depending on what the Adobe event's name was, test whether standard or custom Branch event was fired as well
+        try {
+            BRANCH_STANDARD_EVENT eventType = BRANCH_STANDARD_EVENT.valueOf(event.getName());
+            PrefHelper.Debug("eventType: " + eventType);
+            try {
+                branchSentStandardEvent(branchIsExpectedToRegisterEvent);
+            } catch (NoSuchFieldException | IllegalAccessException | InstantiationException e) {
+                Assert.fail();
+            }
+        } catch (IllegalArgumentException e) {
+            try {
+                branchSentCustomEvent(branchIsExpectedToRegisterEvent);
+            } catch (NoSuchFieldException | IllegalAccessException | InstantiationException ee) {
+                Assert.fail();
+            }
+        }
+
+        PrefHelper.Debug("sendEvent (END)  -- " + event.getName());
+    }
+
+    protected void branchSentStandardEvent(final boolean branchIsExpectedToRegisterEvent) throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+        branchSentEvent("standard", branchIsExpectedToRegisterEvent);
+    }
+
+    protected void branchSentCustomEvent(final boolean branchIsExpectedToRegisterEvent) throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+        branchSentEvent("custom", branchIsExpectedToRegisterEvent);
+    }
+
+    protected void branchSentEvent(String urlSignature, final boolean branchIsExpectedToRegisterEvent) throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+        Branch privateObject = Branch.getInstance();
+        Field privateMapField = Branch.class.getDeclaredField("instrumentationExtraData_");
+        privateMapField.setAccessible(true);
+        ConcurrentHashMap<String, String> instrumentationExtraData_ = (ConcurrentHashMap) privateMapField.get(privateObject);
+
+        Assert.assertNotNull(instrumentationExtraData_);
+
+        Assert.assertEquals(branchIsExpectedToRegisterEvent, oneOfMapKeysContains(instrumentationExtraData_, urlSignature));
+
+        // reset instrumentation
+        privateMapField.set(privateObject, new ConcurrentHashMap<String, String>());
+        ConcurrentHashMap<String, String> instrumentationExtraData_1 = (ConcurrentHashMap) privateMapField.get(privateObject);
+        Assert.assertEquals(0, instrumentationExtraData_1.size());
+    }
+
+    protected boolean oneOfMapKeysContains(Map<String, String> map, String word) {
+        for (String key : map.keySet()) {
+            if (key.contains(word)) return true;
+        }
+        return false;
+    }
+
+    protected void testTrackCustomStateWithExpectation(boolean expectation) throws InterruptedException, NoSuchFieldException, IllegalAccessException, InstantiationException {
+        MobileCore.trackState("testTrackState", new HashMap<String, String>());
+        Thread.sleep(2000);
+        branchSentCustomEvent(expectation);
+    }
+
+    protected void testTrackStandardStateWithExpectation(boolean expectation) throws InterruptedException, NoSuchFieldException, IllegalAccessException, InstantiationException {
+        MobileCore.trackState("PURCHASE", new HashMap<String, String>());
+        Thread.sleep(2000);
+        branchSentStandardEvent(expectation);
+    }
+
+    protected void testTrackCustomActionWithExpectation(boolean expectation) throws InterruptedException, NoSuchFieldException, IllegalAccessException, InstantiationException {
+        MobileCore.trackAction("testTrackCustomAction", new HashMap<String, String>());
+        Thread.sleep(2000);
+        branchSentCustomEvent(expectation);
+    }
+
+    protected void testTrackStandardActionWithExpectation(boolean expectation) throws InterruptedException, NoSuchFieldException, IllegalAccessException, InstantiationException {
+        MobileCore.trackAction("ADD_TO_CART", new HashMap<String, String>());
+        Thread.sleep(2000);
+        branchSentStandardEvent(expectation);
     }
 }

--- a/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/MockActivity.java
+++ b/AdobeBranchExtension/src/androidTest/java/io/branch/adobe/extension/test/MockActivity.java
@@ -1,0 +1,15 @@
+package io.branch.adobe.extension.test;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.util.Log;
+
+public class MockActivity extends Activity {
+    private static final String TAG = "BranchMockActivity";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Log.d(TAG, "MockActivity Started");
+    }
+}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,9 @@
 # Adobe Branch SDK Extension change log
+- v1.3.0
+  * _*Master Release*_ - September 14, 2020
+  * Pick up Adobe IDs more intelligently
+  * Treat Adobe state and action names as Branch event names, instead of lumping them under one name, "Analytics Track".
+
 - v1.2.1
   * _*Master Release*_ - February 21, 2020
   * Fix session initialization from recent apps list

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=1.2.1
-VERSION_CODE=010201
+VERSION_NAME=1.3.0
+VERSION_CODE=010300
 GROUP=io.branch.sdk.android
 
 POM_NAME=Branch Adobe Android SDK


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/INTENG-10910

## Description
pick up event names when they are fired via `MobileCore.trackState` and/or `MobileCore.trackAction`, add better tests

## Testing Instructions
Run tests inside `AdobeEventTest` individually, there are some codependencies between tests that make them fail when they run altogether and I didn't have the time to solve that.

## Risk Assessment [`HIGH | MEDIUM | LOW`]
MEDIUM

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

**You can only merge once all of these are checked off!**

- [x] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [x] Conforms to [Style Guides](https://source.android.com/setup/contribute/code-style)
    - [x] Mission critical pieces are documented in code and out of code as needed
- [x] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
