### PR TITLE
[SDK-1245] Added deviceDataSharedState function

### DIFF
--- a/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
+++ b/AdobeBranchExtension/src/main/java/io/branch/adobe/extension/AdobeBranchExtension.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.branch.referral.Branch;
+import io.branch.referral.BranchPluginSupport;
 import io.branch.referral.PrefHelper;
 import io.branch.referral.util.BRANCH_STANDARD_EVENT;
 import io.branch.referral.util.BranchEvent;
@@ -270,6 +271,8 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
                 PrefHelper.Debug(TAG + "Track BranchEvent: " + branchEvent.getEventName());
 
                 branchEvent.logEvent(getAdobeContext());
+
+                deviceDataSharedState(event);
             } catch(Exception e) {
                 PrefHelper.LogAlways(TAG + "handleTrackEvent Exception" + e.getMessage());
             }
@@ -426,5 +429,20 @@ public class AdobeBranchExtension extends Extension implements ExtensionErrorCal
         }
 
         return context;
+    }
+
+    private void deviceDataSharedState(Event event) {
+        ExtensionErrorCallback<ExtensionError> errorCallback = new ExtensionErrorCallback<ExtensionError>() {
+            @Override
+            public void error(final ExtensionError extensionError) {
+                PrefHelper.LogAlways(String.format("An error occurred while retrieving the shared state for configuration %d %s", extensionError.getErrorCode(), extensionError.getErrorName()));
+            }
+        };
+
+        ExtensionApi api = getApi();
+        if (api != null) {
+            Map<String, Object> deviceData = BranchPluginSupport.getInstance().deviceDescription();
+            api.setSharedEventState(deviceData, event, errorCallback);
+        }
     }
 }


### PR DESCRIPTION
## Reference
SDK-1245 -- Adobe Launch Android SDK - allow writing to shared state

## Description
Added a new function to set event shared state to device data. It's called whenever an event is tracked.

## Testing Instructions
Use the new Adobe Branch SDK to get access to the new deviceDescription() function. Then call an event and check the new shared state to see the device data.

## Risk Assessment [`LOW`]

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

**You can only merge once all of these are checked off!**

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
