### PR TITLE
[FIX] Updated gradle publish script

### DIFF
--- a/AdobeBranchExtension/build.gradle
+++ b/AdobeBranchExtension/build.gradle
@@ -43,6 +43,21 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    task androidSourcesJar(type: Jar) {
+        archiveClassifier.set("sources")
+        from android.sourceSets.main.java.srcDirs
+    }
+
+    task androidJavadocs(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    }
+
+    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+        archiveClassifier.set("javadoc")
+        from androidJavadocs.destinationDir
+    }
 }
 
 dependencies {
@@ -73,6 +88,95 @@ dependencies {
     androidTestImplementation project(path: ':AdobeBranchExtension')
 }
 
+def applyCommonConfig = { MavenPublication publication ->
+    publication.groupId = GROUP
+    publication.artifactId = POM_ARTIFACT_ID
+    publication.version = VERSION_NAME
+
+    publication.artifact bundleReleaseAar
+    publication.artifact androidSourcesJar
+    publication.artifact androidJavadocsJar
+
+    publication.pom {
+        name.set(POM_NAME)
+        description.set(POM_DESCRIPTION)
+        url.set(POM_URL)
+
+        developers {
+            developer {
+                id.set(POM_DEVELOPER_ID)
+                name.set(POM_DEVELOPER_NAME)
+            }
+        }
+
+        licenses {
+            license {
+                name.set(POM_LICENCE_NAME)
+                url.set(POM_LICENCE_URL)
+                distribution.set(POM_LICENCE_DIST)
+            }
+        }
+
+        scm {
+            url.set(POM_SCM_URL)
+            connection.set(POM_SCM_CONNECTION)
+            developerConnection.set(POM_SCM_DEV_CONNECTION)
+        }
+
+        withXml {
+            asNode().dependencies.dependency.findAll {
+                it.artifactId.text() == 'okhttp' || it.artifactId.text() == 'firebase-appindexing'
+            }.each { dependency ->
+                def optionalNode = dependency.optional
+                if (optionalNode) {
+                    optionalNode[0].value = 'true'
+                } else {
+                    dependency.appendNode('optional', 'true')
+                }
+            }
+        }
+    }
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+
+            debug(MavenPublication) {
+                applyCommonConfig(delegate as MavenPublication)
+                from components.findByName("debug")
+            }
+
+            release(MavenPublication) {
+                applyCommonConfig(delegate as MavenPublication)
+                from components.findByName("release")
+            }
+        }
+
+        repositories {
+        maven {
+            url = isReleaseBuild() ? getReleaseRepositoryUrl() : getSnapshotRepositoryUrl()
+            credentials {
+                username = getRepositoryUsername()
+                password = getRepositoryPassword()
+            }
+        }
+    }
+    }
+
+    signing {
+        sign publishing.publications.release
+    }
+}
+
+tasks.withType(PublishToMavenRepository).configureEach {
+    if (name.contains("Debug")) {
+        dependsOn assembleDebug
+    } else if (name.contains("Release")) {
+        dependsOn assembleRelease
+    }
+}
+
 def isReleaseBuild() {
     return !VERSION_NAME.contains("SNAPSHOT")
 }
@@ -93,90 +197,4 @@ def getRepositoryUsername() {
 
 def getRepositoryPassword() {
     return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.findByName('release')
-            groupId = GROUP
-            artifactId = POM_ARTIFACT_ID
-            version = VERSION_NAME
-
-//            // Attach sources and Javadocs
-//            artifact androidSourcesJar
-//            artifact androidJavadocsJar
-
-            // Configure POM
-            pom {
-                name.set(POM_NAME)
-                description.set(POM_DESCRIPTION)
-                url.set(POM_URL)
-                packaging = POM_PACKAGING
-
-                scm {
-                    url.set(POM_SCM_URL)
-                    connection.set(POM_SCM_CONNECTION)
-                    developerConnection.set(POM_SCM_DEV_CONNECTION)
-                }
-
-                licenses {
-                    license {
-                        name.set(POM_LICENCE_NAME)
-                        url.set(POM_LICENCE_URL)
-                        distribution.set(POM_LICENCE_DIST)
-                    }
-                }
-
-                developers {
-                    developer {
-                        id.set(POM_DEVELOPER_ID)
-                        name.set(POM_DEVELOPER_NAME)
-                    }
-                }
-
-                // Optional dependencies
-                withXml {
-                    asNode().dependencies.dependency.findAll {
-                        it.artifactId.text() == 'okhttp' || it.artifactId.text() == 'firebase-appindexing'
-                    }.each {
-                        if (it.optional)
-                            it.optional.value = 'true'
-                        else
-                            it.appendNode('optional', 'true')
-                    }
-                }
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            url = isReleaseBuild() ? getReleaseRepositoryUrl() : getSnapshotRepositoryUrl()
-            credentials {
-                username = getRepositoryUsername()
-                password = getRepositoryPassword()
-            }
-        }
-    }
-}
-
-signing {
-    useGpgCmd()
-    sign publishing.publications.mavenJava
-}
-
-task androidSourcesJar(type: Jar) {
-    archiveClassifier.set("sources")
-    from android.sourceSets.main.java.srcDirs
-}
-
-task androidJavadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    archiveClassifier.set("javadoc")
-    from androidJavadocs.destinationDir
 }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Adobe Branch SDK Extension change log
 
+- 3.0.1
+  * Nov 19, 2024
+  * Fix for missing .aar in 3.0.0
+
 - 3.0.0
   * Nov 18, 2024
   * Update Branch Android SDK to 5.14.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=3.0.0
-VERSION_CODE=300000
+VERSION_NAME=3.0.1
+VERSION_CODE=300001
 GROUP=io.branch.sdk.android
 
 POM_NAME=Branch Adobe Android SDK


### PR DESCRIPTION
The last update changed the gradle build script and a missing line caused the publish to be successful, but not include the actual .aar itself, as seen here: https://repo.maven.apache.org/maven2/io/branch/sdk/android/adobebranchextension/3.0.0/

This change updates the build.gradle to include the release aar by adding the ` publication.artifact bundleReleaseAar` line. This PR also fixes a issue with signing so it works smoother, as it did before.

This is also the release PR for v3.0.1